### PR TITLE
Fix loading of channels in agent view to load all

### DIFF
--- a/assets/js/agent/app.vue
+++ b/assets/js/agent/app.vue
@@ -91,13 +91,6 @@
           }).map(me.getChannelViewModel);
           me.activateChannel(channels.length && channels[0]);
         });
-
-        this.realmq.channels.list().then(function (channelList) {
-          $data.channels = channelList.items.sort(function (a, b) {
-            return a.createdAt < b.createdAt ? 1 : -1;
-          }).map(me.getChannelViewModel);
-          me.activateChannel(channelList.count && channelList.items[0]);
-        });
       },
 
       getChannelViewModel: function(channel) {


### PR DESCRIPTION
The agent view loaded the channels with only a single call without any
parameters. This caused the chat selection to contain only the first
20 ever created channels. Now all channels will be loaded via subsequent
request with increasing limit.

With growing number of chats some sorting and lazy loading may be helpful.